### PR TITLE
QE-3257: Add logic to copy logs for allure report

### DIFF
--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -35,6 +35,7 @@ class AllureListener:
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value=platform_label()))
         test_case.labels.append(Label(name=LabelType.PARENT_SUITE, value=get_domain_name(test)))
         test_case.labels.append(Label(name=LabelType.SUB_SUITE, value=get_file_name(test)))
+        test_case.status = Status.PASSED
         test_case.parameters = params(test)
         self.reporter.schedule_test(self.current_test_uuid, test_case)
 

--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -8,7 +8,7 @@ from allure_commons.model2 import Parameter, Label, Link, StatusDetails, Status,
 from allure_commons.utils import uuid4
 from allure_commons.utils import now
 from allure_commons.utils import platform_label
-from xmlrunner.allure_report.utils import get_file_name, fullname, name, labels, params,get_domain_name,copy_log_file
+from xmlrunner.allure_report.utils import get_file_name, fullname, name, labels, params, get_domain_name, copy_log_file
 
 
 class AllureListener:
@@ -19,15 +19,51 @@ class AllureListener:
         self._thread = thread_tag()
         self.reporter = AllureReporter()
         self.current_test_uuid = None
+        self.isAPITest = False
 
     def start_test(self, test):
+        test_case = self.reporter.get_test(None)
+        if test_case is None:
+            test_case = self.create_test_case(test)
+        self.reporter.schedule_test(self.current_test_uuid, test_case)
+
+    def stop_test(self, test):
+        test_case = self.reporter.get_test(None)
+        if copy_log_file(test):
+            test_case.attachments.append(
+                Attachment(name=f"{get_file_name(test)}.log", source=f"{get_file_name(test)}.log", type="text/plain"))
+        test_case.stop = now()
+        self.reporter.close_test(self.current_test_uuid)
+
+    def add_failure(self, test, err, info_traceback, message="The test is failed"):
+        if self.current_test_uuid is None:
+            self.create_test_case(test)
+        test_case = self.reporter.get_test(None)
+        test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
+        screenshot_name = get_file_name(test) + '_' + name(test)
+        test_case.attachments.append(
+            Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
+        test_case.status = Status.FAILED
+        self.reporter.schedule_test(self.current_test_uuid, test_case)
+
+    def add_error(self, test, err, info_traceback, message="The test is error"):
+        if self.current_test_uuid is None:
+            self.create_test_case(test)
+        test_case = self.reporter.get_test(None)
+        screenshot_name = get_file_name(test) + '_' + name(test)
+        test_case.attachments.append(
+            Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
+        test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
+        test_case.status = Status.BROKEN
+        self.reporter.schedule_test(self.current_test_uuid, test_case)
+
+    def create_test_case(self, test):
         self.current_test_uuid = uuid4()
         test_case = TestResult(uuid=self.current_test_uuid, start=now())
         test_case.name = name(test)
         test_case.fullName = fullname(test)
         test_case.testCaseId = md5(test_case.fullName)
         test_case.historyId = md5(test.id())
-        test_case.status = Status.PASSED
         test_case.labels.extend(labels(test))
         test_case.labels.append(Label(name=LabelType.HOST, value=self._host))
         test_case.labels.append(Label(name=LabelType.THREAD, value=self._thread))
@@ -37,33 +73,8 @@ class AllureListener:
         test_case.labels.append(Label(name=LabelType.PARENT_SUITE, value=get_domain_name(test)))
         test_case.labels.append(Label(name=LabelType.SUB_SUITE, value=get_file_name(test)))
         test_case.parameters = params(test)
-        self.reporter.schedule_test(self.current_test_uuid, test_case)
+        return test_case
 
-    def stop_test(self, test):
-        test_case = self.reporter.get_test(None)
-        test_case.attachments.append(
-            Attachment(name=f"{get_file_name(test)}.log", source=f"{get_file_name(test)}.log", type="text/plain"))
-        test_case.stop = now()
-        copy_log_file(test)
-        self.reporter.close_test(self.current_test_uuid)
-
-    def add_failure(self, test, err, info_traceback, message="The test is failed"):
-        screenshot_name = get_file_name(test) + '_' + name(test)
-        test_case = self.reporter.get_test(None)
-        test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
-        test_case.attachments.append(
-            Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
-        test_case.status = Status.FAILED
-        self.reporter.schedule_test(self.current_test_uuid, test_case)
-
-    def add_error(self, test, err, info_traceback, message="The test is error"):
-        test_case = self.reporter.get_test(None)
-        test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
-        screenshot_name = get_file_name(test) + '_' + name(test)
-        test_case.attachments.append(
-            Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
-        test_case.status = Status.BROKEN
-        self.reporter.schedule_test(self.current_test_uuid, test_case)
 
     # Allure Hooks Spec
     @allure_commons.hookimpl

--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -48,7 +48,6 @@ class AllureListener:
 
     def add_failure(self, test, err, info_traceback, message="The test is failed"):
         test_case = self.reporter.get_test(None)
-        test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
         screenshot_name = get_file_name(test) + '_' + name(test)
         test_case.attachments.append(
             Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
@@ -57,8 +56,8 @@ class AllureListener:
         self.reporter.schedule_test(self.current_test_uuid, test_case)
 
     def add_error(self, test, err, info_traceback, message="The test is error"):
-        screenshot_name = get_file_name(test) + '_' + name(test)
         test_case = self.reporter.get_test(None)
+        screenshot_name = get_file_name(test) + '_' + name(test)
         test_case.attachments.append(
             Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
         test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)

--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -1,7 +1,6 @@
 import allure_commons
 from allure_commons.utils import host_tag, thread_tag
 from allure_commons.utils import md5
-# Going to use for Allure class
 from allure_commons.reporter import AllureReporter
 from allure_commons.types import LabelType, LinkType
 from allure_commons.model2 import TestResult
@@ -9,9 +8,7 @@ from allure_commons.model2 import Parameter, Label, Link, StatusDetails, Status,
 from allure_commons.utils import uuid4
 from allure_commons.utils import now
 from allure_commons.utils import platform_label
-
-# -------------------------------------------------
-from xmlrunner.allure_report.utils import get_file_name, fullname, name, labels, params,get_domain_name
+from xmlrunner.allure_report.utils import get_file_name, fullname, name, labels, params,get_domain_name,copy_log_file
 
 
 class AllureListener:
@@ -47,6 +44,7 @@ class AllureListener:
         test_case.attachments.append(
             Attachment(name=f"{get_file_name(test)}.log", source=f"{get_file_name(test)}.log", type="text/plain"))
         test_case.stop = now()
+        copy_log_file(test)
         self.reporter.close_test(self.current_test_uuid)
 
     def add_failure(self, test, err, info_traceback, message="The test is failed"):

--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -40,6 +40,7 @@ class AllureListener:
 
     def stop_test(self, test):
         test_case = self.reporter.get_test(None)
+        # Check if the file is copied successfully.
         if copy_log_file(test):
             test_case.attachments.append(
                 Attachment(name=f"{get_file_name(test)}.log", source=f"{get_file_name(test)}.log", type="text/plain"))
@@ -93,7 +94,6 @@ class AllureListener:
         self.reporter.attach_file(self.current_test_uuid, source, name=name, attachment_type=attachment_type,
                                   extension=extension)
 
-    #
     @allure_commons.hookimpl
     def add_link(self, url, link_type, name):
         test_case = self.reporter.get_test(None)

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -39,6 +39,12 @@ def get_domain_name(test):
 
 
 def copy_log_file(test):
+    """ Copy the log file from logs folder to specific test suite.
+
+    :param test: The current test from TestCase Class
+    :return:     True (if the file is existed in the logs folder) False (if the file doesn't exist)
+
+    """
     test_name = get_file_name(test)
     org_file = posixpath.join("logs", test_name + ".log")
     if os.path.isfile(org_file):

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -1,4 +1,6 @@
 import inspect
+import shutil
+import posixpath
 from allure_commons.model2 import Label
 from allure_commons.model2 import Parameter
 from allure_commons.utils import represent
@@ -34,6 +36,15 @@ def get_domain_name(test):
     if test.DOMAIN is None:
         return "Default"
     return str(test.DOMAIN)
+
+
+def copy_log_file(test):
+    test_name = get_file_name(test)
+    org_file = posixpath.join("logs", test_name + ".log")
+    if os.path.isfile(org_file):
+        des_file = posixpath.join("test-reports", "allure-results", get_domain_name(test), test_name,
+                                  test_name + ".log")
+        shutil.copy2(org_file, des_file)
 
 
 def update_attrs(test, name, values):

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -45,6 +45,9 @@ def copy_log_file(test):
         des_file = posixpath.join("test-reports", "allure-results", get_domain_name(test), test_name,
                                   test_name + ".log")
         shutil.copy2(org_file, des_file)
+        return True
+    else:
+        return False
 
 
 def update_attrs(test, name, values):


### PR DESCRIPTION
Ticket: [QE-3257](https://jira.q2ebanking.com/browse/QE-3257)
- Adding copy log logic to the allure report
- We use shutil module for copy file