### PR TITLE
QE-3278: Allure report doesn't capture setup class failure

### DIFF
--- a/xmlrunner/allure_report/hook.py
+++ b/xmlrunner/allure_report/hook.py
@@ -2,7 +2,6 @@ import os
 from allure_commons import plugin_manager
 from allure_commons.logger import AllureFileLogger
 from xmlrunner.allure_report.listener import AllureListener
-from xmlrunner.allure_report.utils import get_file_name, get_domain_name
 
 
 class AllureHook:
@@ -11,11 +10,8 @@ class AllureHook:
         self.file_logger = None
         self.listener = AllureListener()
 
-    def register_allure_plugins(self, test):
-        test_runner = test._tests[-1]._tests[0]
-        dir_name = os.path.join("test-reports", "allure-results", get_domain_name(test_runner),
-                                get_file_name(test_runner))
-
+    def register_allure_plugins(self, test, file_name, domain):
+        dir_name = os.path.join("test-reports", "allure-results", domain, file_name)
         self.file_logger = AllureFileLogger(dir_name, clean=True)
         plugin_manager.register(self.listener)
         plugin_manager.register(self.file_logger)

--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -8,17 +8,18 @@ from allure_commons.model2 import Parameter, Label, Link, StatusDetails, Status,
 from allure_commons.utils import uuid4
 from allure_commons.utils import now
 from allure_commons.utils import platform_label
-from xmlrunner.allure_report.utils import get_file_name, fullname, name, labels, params, get_domain_name, copy_log_file
+from xmlrunner.allure_report.utils import get_file_name, get_test_name, labels, params, copy_log_file
 
 
 class AllureListener:
 
-    def __init__(self,domain=None):
+    def __init__(self, domain="Default", file_name=None):
         # need to add config here
         self._host = host_tag()
         self._thread = thread_tag()
         self.reporter = AllureReporter()
         self.test_domain = domain
+        self.file_name = file_name
         self.current_test_uuid = None
 
     def start_test(self, test):
@@ -35,7 +36,7 @@ class AllureListener:
 
     def add_failure(self, test, err, info_traceback, message="The test is failed"):
         test_case = self.reporter.get_test(None)
-        screenshot_name = get_file_name(test) + '_' + name(test)
+        screenshot_name = get_file_name(test) + '_' + get_test_name(test)
         test_case.attachments.append(
             Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
         test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
@@ -43,22 +44,25 @@ class AllureListener:
         self.reporter.schedule_test(self.current_test_uuid, test_case)
 
     def add_error(self, test, err, info_traceback, message="The test is error"):
-
-        if self.current_test_uuid == None:
+        if self.reporter.get_test(self.current_test_uuid) == None:
             self.create_test_case(test)
-        test_case = self.reporter.get_test(None)
-        screenshot_name = get_file_name(test) + '_' + name(test)
+        test_case = self.reporter.get_test(self.current_test_uuid)
+        screenshot_name = get_file_name(test) + '_' + get_test_name(test)
         test_case.attachments.append(
             Attachment(name=screenshot_name, source=f"{screenshot_name}.png", type="image/png"))
         test_case.statusDetails = StatusDetails(message=message, trace=info_traceback)
         test_case.status = Status.BROKEN
-        self.reporter.schedule_test(self.current_test_uuid, test_case)
+        if get_test_name(test) == "setupClass":
+            test_case.stop = now()
+            self.reporter.close_test(self.current_test_uuid)
+        else:
+            self.reporter.schedule_test(self.current_test_uuid, test_case)
 
     def create_test_case(self, test):
         self.current_test_uuid = uuid4()
         test_case = TestResult(uuid=self.current_test_uuid, start=now())
-        test_case.name = name(test)
-        test_case.fullName = fullname(test)
+        test_case.name = get_test_name(test)
+        test_case.fullName = f"{self.file_name}.{get_test_name(test)}"
         test_case.testCaseId = md5(test_case.fullName)
         test_case.historyId = md5(test.id())
         test_case.labels.extend(labels(test))
@@ -67,8 +71,8 @@ class AllureListener:
         test_case.labels.append(Label(name=LabelType.FRAMEWORK, value='unittest'))
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value='python'))
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value=platform_label()))
-        test_case.labels.append(Label(name=LabelType.PARENT_SUITE, value=get_domain_name(test)))
-        test_case.labels.append(Label(name=LabelType.SUB_SUITE, value=get_file_name(test)))
+        test_case.labels.append(Label(name=LabelType.PARENT_SUITE, value=self.test_domain))
+        test_case.labels.append(Label(name=LabelType.SUB_SUITE, value=self.file_name))
         test_case.status = Status.PASSED
         test_case.parameters = params(test)
         self.reporter.schedule_test(self.current_test_uuid, test_case)

--- a/xmlrunner/allure_report/listener.py
+++ b/xmlrunner/allure_report/listener.py
@@ -70,8 +70,8 @@ class AllureListener:
         test_case.labels.append(Label(name=LabelType.FRAMEWORK, value='unittest'))
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value='python'))
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value=platform_label()))
-        test_case.labels.append(Label(name=LabelType.PARENT_SUITE, value=self.file_name))
-        test_case.labels.append(Label(name=LabelType.SUB_SUITE, value=self.test_domain))
+        test_case.labels.append(Label(name=LabelType.PARENT_SUITE, value=self.test_domain))
+        test_case.labels.append(Label(name=LabelType.SUB_SUITE, value=self.file_name))
         test_case.status = Status.PASSED
         test_case.parameters = params(test)
         self.reporter.schedule_test(self.current_test_uuid, test_case)

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -8,44 +8,47 @@ from allure_commons.utils import represent
 import os
 
 
-def name(test):
-    full_name = fullname(test)
-    test_params = params(test)
-    allure_name = full_name.split(".")[-1]
-    if test_params:
-        params_str = "-".join([p.value for p in test_params])
-        return f"{allure_name}[{params_str}]"
-    return allure_name
+def get_test_name(test):
+    """ Get the test name from the test case object.
 
+    :param test: The current test from TestCase Class
+    :return:     The test_name for the current test case.
 
-def fullname(test):
+    """
+    test_name = ""
     if hasattr(test, "_testFunc"):
-        suit_name = test._testFunc.__module__
         test_name = test._testFunc.__name__
-        return f"{suit_name}.{test_name}"
+        return test_name
     test_info = test.id()
-    suit_name = test_name = ""
     # check if this is a setup class
     if test_info.startswith("setUpClass"):
-        test_splits = test_info.split(" ")
-        test_name = test_splits[0]
-        suit_name = test_splits[1].strip('()').split('.')[1]
-        print(suit_name)
+        test_name = test_info.split(" ")[0]
     else:
         suit_name, test_name = test_info.split(".")[1:]
-    return f"{suit_name}.{test_name}"
+    return test_name
 
 
 def get_file_name(test):
+    """ Get the test name from the test case object.
+
+    :param test: The current test from TestCase Class
+    :return:     The current file name of the test.
+
+    """
     file_name = os.path.basename(inspect.getfile(type(test))).split(".")[0]
     return file_name
 
 
 def get_domain_name(test):
+    """ Get the test name from the test case object.
+
+    :param test: The current test from TestCase Class
+    :return:     The domain for the current test case.
+
+    """
     if test.DOMAIN is None:
         return "Default"
     return str(test.DOMAIN)
-
 
 
 def copy_log_file(test):

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -40,7 +40,7 @@ def get_file_name(test):
 
 
 def get_domain_name(test):
-    """ Get the test name from the test case object.
+    """ Get the test domain from the test case object.
 
     :param test: The current test from TestCase Class
     :return:     The domain for the current test case.

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import shutil
 import posixpath
+import re
 from allure_commons.model2 import Label
 from allure_commons.model2 import Parameter
 from allure_commons.utils import represent
@@ -22,8 +23,16 @@ def fullname(test):
         suit_name = test._testFunc.__module__
         test_name = test._testFunc.__name__
         return f"{suit_name}.{test_name}"
-    test_id = test.id()
-    suit_name, test_name = test_id.split(".")[1:]
+    test_info = test.id()
+    suit_name = test_name = ""
+    # check if this is a setup class
+    if test_info.startswith("setUpClass"):
+        test_splits = test_info.split(" ")
+        test_name = test_splits[0]
+        suit_name = test_splits[1].strip('()').split('.')[1]
+        print(suit_name)
+    else:
+        suit_name, test_name = test_info.split(".")[1:]
     return f"{suit_name}.{test_name}"
 
 
@@ -36,6 +45,7 @@ def get_domain_name(test):
     if test.DOMAIN is None:
         return "Default"
     return str(test.DOMAIN)
+
 
 
 def copy_log_file(test):

--- a/xmlrunner/allure_report/utils.py
+++ b/xmlrunner/allure_report/utils.py
@@ -51,17 +51,16 @@ def get_domain_name(test):
     return str(test.DOMAIN)
 
 
-def copy_log_file(test):
+def copy_log_file(test_name, domain_name):
     """ Copy the log file from logs folder to specific test suite.
 
-    :param test: The current test from TestCase Class
+    :param test_name: The current test name from TestCase Class
     :return:     True (if the file is existed in the logs folder) False (if the file doesn't exist)
 
     """
-    test_name = get_file_name(test)
     org_file = posixpath.join("logs", test_name + ".log")
     if os.path.isfile(org_file):
-        des_file = posixpath.join("test-reports", "allure-results", get_domain_name(test), test_name,
+        des_file = posixpath.join("test-reports", "allure-results", domain_name, test_name,
                                   test_name + ".log")
         shutil.copy2(org_file, des_file)
         return True

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -195,7 +195,7 @@ class _XMLTestResult(TextTestResult):
     Used by XMLTestRunner.
     """
 
-    def __init__(self, domain=None, stream=sys.stderr, descriptions=1, verbosity=1,
+    def __init__(self, domain=None, file_name=None, stream=sys.stderr, descriptions=1, verbosity=1,
                  elapsed_times=True, properties=None, infoclass=None):
         TextTestResult.__init__(self, stream, descriptions, verbosity)
         self._stdout_data = None
@@ -212,7 +212,7 @@ class _XMLTestResult(TextTestResult):
         self.lineno = None
         self.doc = None
         # Adding allure listener
-        self.allure_listener = AllureListener(domain)
+        self.allure_listener = AllureListener(domain=domain, file_name=file_name)
         if infoclass is None:
             self.infoclass = _TestInfo
         else:

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -195,7 +195,7 @@ class _XMLTestResult(TextTestResult):
     Used by XMLTestRunner.
     """
 
-    def __init__(self, file_name=None, domain=None, stream=sys.stderr, descriptions=1, verbosity=1,
+    def __init__(self, stream=sys.stderr, descriptions=1, verbosity=1,
                  elapsed_times=True, properties=None, infoclass=None):
         TextTestResult.__init__(self, stream, descriptions, verbosity)
         self._stdout_data = None
@@ -211,7 +211,7 @@ class _XMLTestResult(TextTestResult):
         self.filename = None
         self.lineno = None
         self.doc = None
-        self.allure_listener = AllureListener(domain, file_name)
+        self.allure_listener = AllureListener()
         if infoclass is None:
             self.infoclass = _TestInfo
         else:

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -195,7 +195,7 @@ class _XMLTestResult(TextTestResult):
     Used by XMLTestRunner.
     """
 
-    def __init__(self, domain=None, file_name=None, stream=sys.stderr, descriptions=1, verbosity=1,
+    def __init__(self, file_name=None, domain=None, stream=sys.stderr, descriptions=1, verbosity=1,
                  elapsed_times=True, properties=None, infoclass=None):
         TextTestResult.__init__(self, stream, descriptions, verbosity)
         self._stdout_data = None
@@ -211,8 +211,7 @@ class _XMLTestResult(TextTestResult):
         self.filename = None
         self.lineno = None
         self.doc = None
-        # Adding allure listener
-        self.allure_listener = AllureListener(domain=domain, file_name=file_name)
+        self.allure_listener = AllureListener(domain, file_name)
         if infoclass is None:
             self.infoclass = _TestInfo
         else:

--- a/xmlrunner/result.py
+++ b/xmlrunner/result.py
@@ -195,7 +195,7 @@ class _XMLTestResult(TextTestResult):
     Used by XMLTestRunner.
     """
 
-    def __init__(self, stream=sys.stderr, descriptions=1, verbosity=1,
+    def __init__(self, domain=None, stream=sys.stderr, descriptions=1, verbosity=1,
                  elapsed_times=True, properties=None, infoclass=None):
         TextTestResult.__init__(self, stream, descriptions, verbosity)
         self._stdout_data = None
@@ -212,7 +212,7 @@ class _XMLTestResult(TextTestResult):
         self.lineno = None
         self.doc = None
         # Adding allure listener
-        self.allure_listener = AllureListener()
+        self.allure_listener = AllureListener(domain)
         if infoclass is None:
             self.infoclass = _TestInfo
         else:

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -1,4 +1,3 @@
-
 import argparse
 import sys
 import time
@@ -6,8 +5,9 @@ import time
 from .unittest import TextTestRunner, TestProgram
 from .result import _XMLTestResult
 
-#---------------------------------------------------
+# ---------------------------------------------------
 from xmlrunner.allure_report.hook import AllureHook
+
 # see issue #74, the encoding name needs to be one of
 # http://www.iana.org/assignments/character-sets/character-sets.xhtml
 UTF8 = 'UTF-8'
@@ -37,14 +37,14 @@ class XMLTestRunner(TextTestRunner):
         else:
             self.resultclass = resultclass
 
-    def _make_result(self):
+    def _make_result(self, domain="Default"):
         """
         Creates a TestResult object which will be used to store
         information about the executed tests.
         """
         # override in subclasses if necessary.
         return self.resultclass(
-            self.stream, self.descriptions, self.verbosity, self.elapsed_times
+            domain, self.stream, self.descriptions, self.verbosity, self.elapsed_times
         )
 
     def run(self, test):
@@ -53,7 +53,8 @@ class XMLTestRunner(TextTestRunner):
         """
         try:
             # Prepare the test execution
-            result = self._make_result()
+            test_runner = test._tests[-1]._tests[0]
+            result = self._make_result(test_runner.DOMAIN)
             result.failfast = self.failfast
             result.buffer = self.buffer
             if hasattr(test, 'properties'):
@@ -80,7 +81,7 @@ class XMLTestRunner(TextTestRunner):
             run = result.testsRun
             self.stream.writeln("Ran %d test%s in %.3fs" % (
                 run, run != 1 and "s" or "", time_taken)
-            )
+                                )
             self.stream.writeln()
 
             # other metrics

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -63,7 +63,9 @@ class XMLTestRunner(TextTestRunner):
             test_runner = test._tests[-1]._tests[0]
             file_name = os.path.basename(inspect.getfile(type(test_runner))).split(".")[0]
             domain = test_runner.DOMAIN
-            result = self._make_result(domain=domain, file_name=file_name)
+            if domain is None:
+                domain = "Default"
+            result = self._make_result(file_name=file_name, domain=domain)
             result.failfast = self.failfast
             result.buffer = self.buffer
             if hasattr(test, 'properties'):

--- a/xmlrunner/runner.py
+++ b/xmlrunner/runner.py
@@ -39,16 +39,11 @@ class XMLTestRunner(TextTestRunner):
         else:
             self.resultclass = resultclass
 
-    def _make_result(self, **kwargs):
+    def _make_result(self):
         """
         Creates a TestResult object which will be used to store
         information about the executed tests.
         """
-        if kwargs.get("domain", None) and kwargs.get("file_name", None):
-            return self.resultclass(
-                kwargs["file_name"], kwargs["domain"], self.stream, self.descriptions, self.verbosity,
-                self.elapsed_times
-            )
         # override in subclasses if necessary.
         return self.resultclass(
             self.stream, self.descriptions, self.verbosity, self.elapsed_times
@@ -65,7 +60,9 @@ class XMLTestRunner(TextTestRunner):
             domain = test_runner.DOMAIN
             if domain is None:
                 domain = "Default"
-            result = self._make_result(file_name=file_name, domain=domain)
+            result = self._make_result()
+            result.allure_listener.file_name = file_name
+            result.allure_listener.test_domain = domain
             result.failfast = self.failfast
             result.buffer = self.buffer
             if hasattr(test, 'properties'):


### PR DESCRIPTION
# QE-3279: Allure report doesn't capture setup class failure

## Problem:
- Allure report fails to generate a report if the setUpClass has  an error

## Additional Comments:
- Unittest treats both test case error and code error as the same.
- They use the same hook to handle both cases.
- When we build a  error hook for allure report, we must handle the case when the setUpClass failed and return an ErrorHandler class object that doesn't contain test name.
- Since we get the information from the test that passed into the hook, if the test doesn't contains the description for the test name then we can't extract the test name from it.

## Current Behavior:

- Code breaks and can't create a test report if the setUpClass is error

## Solution:

- Since we knows, code breaks because we can't generate the test case from the ErrorHandler object cause we can't get the test name , file_name, and domain, we must store the file name and domain when we start test runner.
- We also remove name function and change full name function to get test name such that we only care for the test name,
